### PR TITLE
Refactor Boltzmann Inversion for angles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # IDE files
 .idea/
 settings.json
+.vscode/
 
 # Input / Output files
 /fftest.ff

--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,20 @@
-*.pyc
+# IDE files
 .idea/
-.cache/
+settings.json
+
+# Input / Output files
+/fftest.ff
 /*.gro
 /*.itp
-/fftest.ff
-/env
-/minenv
+*.offsets
+
+# Environment
+.cache/
 .coverage
 /cover
-/tmp
 /doc/build
+/env
+/minenv
 /nose2-junit.xml
-*.offsets
+*.pyc
+/tmp

--- a/pycgtool/functionalforms.py
+++ b/pycgtool/functionalforms.py
@@ -3,7 +3,7 @@ import math
 
 import numpy as np
 
-from pycgtool.util import SimpleEnum, circular_mean, circular_variance
+from pycgtool.util import SimpleEnum
 
 
 class FunctionalForms(object):

--- a/test/test_functionalforms.py
+++ b/test/test_functionalforms.py
@@ -6,7 +6,6 @@ from pycgtool.functionalforms import FunctionalForms, FunctionalForm
 from pycgtool.util import circular_mean, circular_variance
 
 
-# TODO test injection of mean / variance functions
 class FunctionalFormTest(unittest.TestCase):
     def test_functional_form(self):
         funcs = FunctionalForms()

--- a/test/test_functionalforms.py
+++ b/test/test_functionalforms.py
@@ -1,6 +1,9 @@
 import unittest
 
+import numpy as np
+
 from pycgtool.functionalforms import FunctionalForms, FunctionalForm
+from pycgtool.util import circular_mean, circular_variance
 
 
 # TODO test injection of mean / variance functions
@@ -28,6 +31,48 @@ class FunctionalFormTest(unittest.TestCase):
         self.assertIn("TestFunc", funcs)
         self.assertEqual("TestResultEqm", funcs.TestFunc.eqm(None, None))
         self.assertEqual("TestResultFconst", funcs.TestFunc.fconst(None, None))
+
+    def test_inject_mean_function(self):
+        """
+        Test injecting mean function into Boltzmann Inversion
+        """
+        funcs = FunctionalForms()
+        vals = [0.25 * np.pi, 1.75 * np.pi]
+
+        func = funcs["Harmonic"]()
+
+        np.testing.assert_allclose(
+            func.eqm(vals, None), np.pi
+        )
+
+        func = funcs["Harmonic"](
+            mean_func=circular_mean
+        )
+
+        np.testing.assert_allclose(
+            func.eqm(vals, None), 0,
+            atol=1e-6
+        )
+
+    def test_inject_variance_function(self):
+        """
+        Test injecting variance function into Boltzmann Inversion
+        """
+        funcs = FunctionalForms()
+
+        func = funcs["Harmonic"](
+            variance_func=circular_variance
+        )
+
+        vals = [0, 0.5 * np.pi]
+        ref = func.fconst(vals, 300)
+
+        vals = [0.25 * np.pi, 1.75 * np.pi]
+        np.testing.assert_allclose(
+            func.fconst(vals, 300), ref,
+            atol=0
+        )
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_functionalforms.py
+++ b/test/test_functionalforms.py
@@ -3,6 +3,7 @@ import unittest
 from pycgtool.functionalforms import FunctionalForms, FunctionalForm
 
 
+# TODO test injection of mean / variance functions
 class FunctionalFormTest(unittest.TestCase):
     def test_functional_form(self):
         funcs = FunctionalForms()


### PR DESCRIPTION
I've refactored the functional form classes for the Boltzmann Inversion to accept functions for calculating the mean and variance using dependency injection.

This means that we don't need different versions of the functional forms for angles - you just provide the circular functions when you define the functional form.  Has the side effect that the functional forms are no longer static classes, but that seems an acceptable loss.

Thoughts?